### PR TITLE
Restore 'tag' as integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Parameters for the data section of the notification.  Everything here is optiona
 | --- | --- | 
 | color | A hex color such as #FF0000, default value is a blue |
 | message_type | 'notification' or 'data', defaults to 'data'.  This is the type of FCM that is sent.  Notification has higher priority, but can't include actions or be dismissed by Home Assistant. |
-| tag | Tag is the 'id' of the notifications.  Sending a new notification to the same tag will overwrite the current notifcation instead of creating a separate one. |
+| tag | Must be an integer. Tag is the 'id' of the notifications. Sending a new notification to the same tag will overwrite the current notifcation instead of creating a separate one. |
 | dismiss | true or false, requires a tag parameter.  If true, the notification will be dismissed. |
 | actions | Array of ojects (up to 3) with an 'action' and 'title'.  The title will be the button text on the notification, the action is what is sent back in the callback |
 | image | A URL of an image to send.  The image overwrites the BigTextStyle so longer texts will be truncated.  The image will also be smaller if actions are included |

--- a/fcm-android.py
+++ b/fcm-android.py
@@ -322,7 +322,10 @@ class FCMAndroidNotificationService(BaseNotificationService):
                 message_type = ATTR_DATA
 
             if data.get(ATTR_TAG) is not None:
-                msg_payload[ATTR_TAG] = data.get(ATTR_TAG)
+                try:
+                    msg_payload[ATTR_TAG] = int(data.get(ATTR_TAG))
+                except ValueError:
+                    _LOGGER.error('%s is not a valid integer!', data.get(ATTR_TAG))
                 if data.get(ATTR_DISMISS) is not None:
                     if isinstance(data.get(ATTR_DISMISS), bool):
                         msg_payload[ATTR_DISMISS] = data.get(ATTR_DISMISS)


### PR DESCRIPTION
The `tag` as a string has stopped working. Maybe a change in FCM? I don't sure. This PR restore the `tag` as an integer and adds better support for `tag` sent as a template from HA.