### PR TITLE
Add compatibility dismiss with HA template

### DIFF
--- a/fcm-android.py
+++ b/fcm-android.py
@@ -326,11 +326,10 @@ class FCMAndroidNotificationService(BaseNotificationService):
                     msg_payload[ATTR_TAG] = int(data.get(ATTR_TAG))
                 except ValueError:
                     _LOGGER.error('%s is not a valid integer!', data.get(ATTR_TAG))
+                msg_payload[ATTR_DISMISS] = False
                 if data.get(ATTR_DISMISS) is not None:
-                    if isinstance(data.get(ATTR_DISMISS), bool):
-                        msg_payload[ATTR_DISMISS] = data.get(ATTR_DISMISS)
-                    else:
-                        _LOGGER.warning('%s is not a valid boolean, false will be used', data.get(ATTR_DISMISS))
+                    if str(data.get(ATTR_DISMISS)).lower() == 'true':
+                        msg_payload[ATTR_DISMISS] = True
 
         payload[message_type] = msg_payload
 


### PR DESCRIPTION
If you send notification with data template all values are strings. For example in this notification `true` for `dismiss` will be string:
```
service: notify.android_oneplus_6
date_template:
  title: 'Notification title'
  message: 'Notification message'
  data:
    tag: '{{ tag }}'
    dismiss: true
```
With this PR component correctly responds for real boolean and strings `true`/`false` for `dismiss`.